### PR TITLE
update spec.emu with import bytes

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -61,7 +61,7 @@ contributors: Steven, Guy Bedford
       <ol>
         <li><p><ins>Let _type_ be _entry_.[[Value]].</ins></p></li>
         <li><p><ins>If _type_ is *"json"*, the host environment must perform FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_), where _result_ is either the Completion Record returned by an invokation of ParseJSONModule or a throw completion.</ins></p></li>
-        <li><p><ins>If _type_ is *"buffer"*, the host environment must perform FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_), where _result_ is either the Completion Record returned by an invokation of CreateBufferModule or a throw completion.</ins></p></li>
+        <li><p><ins>If _type_ is *"bytes"*, the host environment must perform FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_), where _result_ is either the Completion Record returned by an invokation of CreateBytesModule or a throw completion.</ins></p></li>
       </ol>
       <li>
         The operation must treat _payload_ as an opaque value to be passed through to FinishLoadingImportedModule.
@@ -71,11 +71,11 @@ contributors: Steven, Guy Bedford
     <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to load the appropriate Module Record. Multiple different (_referrer_, _moduleRequest_.[[Specifer]], _moduleRequest_.[[Attributes]]) triples may map to the same Module Record instance. The actual mapping semantics is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
 
     <emu-note>
-      <p>The above text implies that hosts *must* support JSON modules <ins>and buffer modules</ins> imported with `type: "json"` <ins>and `type: "buffer"` respectively </ins>(if it completes normally), but it doesn't prohibit hosts from supporting JSON modules imported with no type specified. Some environments (for example, web browsers) plan to require `with { type: "json" }`, and environments which want to restrict themselves to a compatible subset would do so as well.</p>
+      <p>The above text implies that hosts *must* support JSON modules <ins>and bytes modules</ins> imported with `type: "json"` <ins>and `type: "bytes"` respectively </ins>(if it completes normally), but it doesn't prohibit hosts from supporting JSON modules imported with no type specified. Some environments (for example, web browsers) plan to require `with { type: "json" }`, and environments which want to restrict themselves to a compatible subset would do so as well.</p>
     </emu-note>
 
     <emu-note>
-      <p>All of the import statements in the module graph that address the same JSON <ins>or buffer </ins>module may evaluate to the same mutable object.</p>
+      <p>All of the import statements in the module graph that address the same JSON <ins>or bytes </ins>module may evaluate to the same mutable object.</p>
     </emu-note>
   </emu-clause>
 
@@ -84,7 +84,7 @@ contributors: Steven, Guy Bedford
 
     <p>A <dfn variants="Synthetic Module Records">Synthetic Module Record</dfn> is used to represent information about a module that is defined by specifications. Its exports are derived from a pair of lists, of string keys and of ECMAScript values. The set of exported names is static, and determined at creation time (as an argument to CreateSyntheticModule), while the set of exported values can be changed over time using SetSyntheticModuleExport. It has no imports or dependencies.</p>
 
-    <emu-note>A Synthetic Module Record could be used for defining a variety of module types: for example, built-in modules, or JSON modules, <ins>or buffer modules, </ins>or CSS modules.</emu-note>
+    <emu-note>A Synthetic Module Record could be used for defining a variety of module types: for example, built-in modules, or JSON modules, <ins>or bytes modules, </ins>or CSS modules.</emu-note>
 
     <p>In addition to the fields defined in <emu-xref href="#table-module-record-fields"></emu-xref> Synthetic Module Records have the additional fields listed in <emu-xref href="#table-synthetic-module-record-fields"></emu-xref>. Each of these fields is initially set in CreateSyntheticModule.</p>
 
@@ -110,10 +110,10 @@ contributors: Steven, Guy Bedford
       </table>
     </emu-table>
 
-    <emu-clause id="sec-create-buffer-module" type="abstract operation">
+    <emu-clause id="sec-create-bytes-module" type="abstract operation">
       <h1>
         <ins>
-          CreateBufferModule (
+          CreateBytesModule (
             _arrayBuffer_: an immutable ArrayBuffer or a SharedArrayBuffer
           ): a Synthetic Module Record
         </ins>


### PR DESCRIPTION
In PR https://github.com/tc39/proposal-import-bytes/pull/12 we changed the type from `buffer` to `bytes` again and the output was changed from ArrayBuffer to Uint8Array, but the spec was not updated.

This PR updates the spec to match the readme.